### PR TITLE
Add missing import to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ import XMonad.Hooks.DynamicLog
 
 import qualified DBus as D
 import qualified DBus.Client as D
+import qualified Codec.Binary.UTF8.String as UTF8
 
 main :: IO ()
 main = do


### PR DESCRIPTION
Example in README uses `utf8-string` package
and function decodeString but was missing qualified import
of the module